### PR TITLE
Adding shadow-hover-effect to the buttons

### DIFF
--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -5,19 +5,19 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "../../lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-transform duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 active:scale-95",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:"bg-primary text-primary-foreground hover:bg-primary/90 shadow-md hover:shadow-lg",
         destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90 shadow-md hover:shadow-lg",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground shadow-md hover:shadow-lg",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 shadow-md hover:shadow-lg",
+        ghost: "hover:bg-accent hover:text-accent-foreground shadow-none",
+        link: "text-primary underline-offset-4 hover:underline shadow-none",
       },
       size: {
         default: "h-10 px-4 py-2",


### PR DESCRIPTION
issue no #38 

Before clicking the default state of all the buttons
![image](https://github.com/oxiton-foundation/click-metrics/assets/158052549/00036706-90a4-44f1-8004-d84d0ae58ca7)
![image](https://github.com/oxiton-foundation/click-metrics/assets/158052549/f7381b30-e5b3-4727-82f8-13d57dc24b40)


After hovering on it 
![image](https://github.com/oxiton-foundation/click-metrics/assets/158052549/faf42f18-4084-4aaa-9eb6-3719c415b85a)
![image](https://github.com/oxiton-foundation/click-metrics/assets/158052549/711d5425-2af1-4a23-b15d-251116d99e95)
![image](https://github.com/oxiton-foundation/click-metrics/assets/158052549/58c106b5-6b36-4e6f-a4d5-bd71a20d6705)


Please assign me and give necessary tags under GSsOC'24
