### PR TITLE
Bug Fix: Update input field styling in links page

### DIFF
--- a/client/src/components/pages/links.tsx
+++ b/client/src/components/pages/links.tsx
@@ -39,7 +39,7 @@ const Links = () => {
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
           placeholder="https://example.com/my-long-url"
-          className="border p-2 w-full border-gray-300"
+          className="border p-2 w-full border-gray-300 bg-white"
         />
         <Button className="mt-4" onClick={handleSubmit}>
           Generate short link


### PR DESCRIPTION
Fixes: #144 

Changed background for the input area in links section.

Before:
![image](https://github.com/oxiton-foundation/click-metrics/assets/74809468/f60f2cdb-4ba3-4ddf-b7b6-7ec074c1afc8)

After:
![image](https://github.com/oxiton-foundation/click-metrics/assets/74809468/cd9fe13e-951c-40ab-8d5a-ece3cd65af24)
